### PR TITLE
Fixing top section image

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
       </div>
     </div>
 
-<div class="agenda" id="section4">
+<!-- <div class="agenda" id="section4">
   <div class="o-nas" style="margin-bottom: 50px;">AGENDA CONFERENCJI CAIAK</div>
 
   <div class="agenda-desc">
@@ -285,7 +285,7 @@
       <!-- Dodaj więcej kropek, jeśli jest potrzeba -->
     </div>
   </div>
-</div>
+</div> -->
 
 
 

--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
       </div>
     </div>
 
-<!-- <div class="agenda" id="section4">
+<div class="agenda" id="section4">
   <div class="o-nas" style="margin-bottom: 50px;">AGENDA CONFERENCJI CAIAK</div>
 
   <div class="agenda-desc">
@@ -285,7 +285,7 @@
       <!-- Dodaj więcej kropek, jeśli jest potrzeba -->
     </div>
   </div>
-</div> -->
+</div>
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -496,6 +496,13 @@ nav {
 }
 
 @media screen and (max-width: 600px) {
+
+    main {
+        height: 400px;
+        background-position: 58% 15%;
+        background-size: 160%;
+      }
+
   .main-2 {
     display: flex;
     flex-direction: column;
@@ -620,6 +627,13 @@ nav {
 }
 
 @media screen and (max-width: 450px) {
+
+    main {
+        height: 350px;
+        background-position: 58% 13%;
+        background-size: 160%;
+      }
+    
   .flexbox {
     width: 90%;
   }
@@ -633,7 +647,13 @@ nav {
   }
 }
 
-@media screen and (max-width: 300px) {
+@media screen and (max-width: 330px) {
+    main {
+        height: 300px;
+        background-position: 58% 11%;
+        background-size: 160%;
+      }
+
   .flexbox {
     width: 95%;
   }


### PR DESCRIPTION
I've managed to resize top section image so mobile phone users could see more people from our student club. Unfortunately the only way to do it is to make this image smaller. I've attached a screenshot that shows how the screen of a phone would look like now WITHOUT agenda section. With the newest section crashes responsivness a bit but I will fix it tomorrow. 

I've hidden the agenda section to make this fix and screenshot but then I've uncovered it so the agenda section IS visible in this PR.

![image](https://github.com/knsiczarnamagia/knsiczarnamagia.github.io/assets/153948308/43a889ac-d63a-4cd0-bccd-8e4e822ad484)

